### PR TITLE
lint: fix 'isort' rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: isort
         args: [--profile=black, --filter-files]
-        files: id3manager.py
+        files: src/
       - id: isort
         args: [--profile=black, --filter-files, --thirdparty=id3manager]
         files: tests/

--- a/src/id3manager/__main__.py
+++ b/src/id3manager/__main__.py
@@ -6,9 +6,7 @@ import tempfile
 
 import mutagen.mp3 as mp3
 
-from . import metadata
-from . import formats
-
+from . import formats, metadata
 
 EDITOR = os.environ.get("EDITOR", "vi")
 

--- a/src/id3manager/formats/__init__.py
+++ b/src/id3manager/formats/__init__.py
@@ -1,6 +1,5 @@
 from .formats import get_metadata_formatter, get_supported_formats
 
-
 __all__ = [
     "get_metadata_formatter",
     "get_supported_formats",

--- a/src/id3manager/formats/formats.py
+++ b/src/id3manager/formats/formats.py
@@ -4,7 +4,6 @@ from .abc import MetadataFormatter
 from .text import TextMetadataFormatter
 from .toml import TomlMetadataFormatter
 
-
 FORMATTERS = {
     formatter.name: formatter
     for formatter in [TextMetadataFormatter(), TomlMetadataFormatter()]

--- a/src/id3manager/metadata.py
+++ b/src/id3manager/metadata.py
@@ -5,7 +5,6 @@ import mutagen.id3 as id3
 from . import utils
 from .formats import get_metadata_formatter
 
-
 __all__ = [
     "read_metadata",
     "write_metadata",


### PR DESCRIPTION
In commit 6714f1dd564a555acb683545a4a7609bd0603d8b, `id3manager.py` has been split into multiple source files stored in `src/` directory. This broke lint job because isort kept looking for `id3manager.py` in the repository root.