### PR TITLE
set: fix metadata parsing for multiple chapters

### DIFF
--- a/src/id3manager/utils.py
+++ b/src/id3manager/utils.py
@@ -1,8 +1,8 @@
-def parse_timestamp_to_ms(timestamp: str, sep: str = ":") -> float:
+def parse_timestamp_to_ms(timestamp: str, sep: str = ":") -> int:
     parts = [float(part) for part in timestamp.split(sep)]
     parts = [0] * (3 - len(parts)) + parts
     hrs, min, sec = parts
-    return hrs * 60 * 60 + min * 60 + sec
+    return int((hrs * 60 * 60 + min * 60 + sec) * 1000)
 
 
 def ms_to_human_time(ms: int) -> str:

--- a/tests/test_set.py
+++ b/tests/test_set.py
@@ -25,6 +25,54 @@ def test_text_metadata(get_mp3):
     assert expected == actual.decode("utf-8")
 
 
+def test_text_metadata_multiple_chapters(get_mp3):
+    expected = textwrap.dedent(
+        """\
+        TDRC = 2022-10-14
+        TRCK = 12/12
+        TPE1 = Ігор, Роман
+        TALB = Шо по коду?
+        TIT2 = Обробка помилок
+        TCON = Podcast
+
+        00:00:00 Початок
+        00:00:01 Кінець
+        """
+    )
+
+    test_mp3 = get_mp3("metadata.mp3")
+    subprocess.check_output(
+        ["id3manager", "set", test_mp3], input=expected.encode("utf-8")
+    )
+
+    actual = subprocess.check_output(["id3manager", "get", test_mp3])
+    assert expected == actual.decode("utf-8")
+
+
+def test_text_metadata_multiple_chapters_ms(get_mp3):
+    expected = textwrap.dedent(
+        """\
+        TDRC = 2022-10-14
+        TRCK = 12/12
+        TPE1 = Ігор, Роман
+        TALB = Шо по коду?
+        TIT2 = Обробка помилок
+        TCON = Podcast
+
+        00:00:00 Початок
+        00:00:01.123 Кінець
+        """
+    )
+
+    test_mp3 = get_mp3("metadata.mp3")
+    subprocess.check_output(
+        ["id3manager", "set", test_mp3], input=expected.encode("utf-8")
+    )
+
+    actual = subprocess.check_output(["id3manager", "get", test_mp3])
+    assert expected == actual.decode("utf-8")
+
+
 def test_text_no_metadata(get_mp3):
     test_mp3 = get_mp3("no-metadata.mp3")
     expected = textwrap.dedent(


### PR DESCRIPTION
When multiple chapters set in 'metadata.txt', the end time for chapters
was 'float' while 'int' was expected.

Co-authored-by: Roman Podoliaka <roman.podoliaka@gmail.com>
Co-authored-by: Ruslan Kiyanchuk <ruslan.kiyanchuk@gmail.com>