### PR TITLE
Drop support for Python 3.7 that is obsolete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
GitHub Actions fail to set up an environment for Python 3.7. Let's just drop it given that this branch is no longer supported.